### PR TITLE
bug(image-cache-it): fix event name for image load error

### DIFF
--- a/packages/nativescript-image-cache-it/common.ts
+++ b/packages/nativescript-image-cache-it/common.ts
@@ -148,7 +148,7 @@ export class ImageCacheItBase extends View {
 
   _emitErrorEvent(message: string, url: string) {
     this.notify({
-      eventName: ImageCacheItBase.onLoadStartEvent,
+      eventName: ImageCacheItBase.onErrorEvent,
       object: this,
       message,
       url


### PR DESCRIPTION
I noticed that the error events never fire when the image fails to load, which is caused by a mismatch in the event name.